### PR TITLE
fix Error: Redefinition of RCTMethodInfo

### DIFF
--- a/ios/RNSecureStorage.h
+++ b/ios/RNSecureStorage.h
@@ -1,10 +1,12 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#elif __has_include("React/RCTBridgeModule.h")
+#import "React/RCTBridgeModule.h"
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNSecureStorage : NSObject <RCTBridgeModule>
 
 @end
-  
+


### PR DESCRIPTION
closes https://github.com/debris/react-native-secure-storage/issues/1
see https://github.com/facebook/react-native/issues/15775