### PR TITLE
fix: pod setting, types declaration, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@
 
 `$ npm install react-native-secure-storage --save`
 
-### Mostly automatic installation
+### Mostly automatic installation 
 
 `$ react-native link react-native-secure-storage`
 
-### Manual installation
+If you use React Native version >= 0.60, need additionally run:
 
+`$ cd ios && pod install && cd ..`
+
+### Manual installation
 
 #### iOS
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,34 @@
 
 
 ## Usage
+
+* getItem(String key, SecureStoreParams options)
+* setItem(String key, String value, SecureStoreParams options)
+* deleteItem(String key, SecureStoreParams options)
+* getAllItems(SecureStoreParams options)
+
+```typescript
+interface SecureStoreParams {
+    keychainService: string; //used for iOS
+    sharedPreferencesName: string; //used for Android
+}
+```
+
+### Example
 ```javascript
 import RNSecureStorage from 'react-native-secure-storage';
 
-// TODO: What to do with the module?
-RNSecureStorage;
-```
+const storeParams = {
+  keychainService: 'accounts_example_app_ios',
+  sharedPreferencesName: 'accounts_example_app_android',
+}
+
+async function RNSecureStorageExample () {
+  await RNSecureStorage.setItem('sunny_day', '365', storeParams);
+  const saveValue = await RNSecureStorage.getItem('sunny_day', storeParams);
   
+  const allEntries = await RNSecureStorage.getAllItems(storeParams);
+  //all Entries is an object with key as string and value as string;
+  await RNSecureStorage.deleteItem('sunny_day', storeParams);
+}
+```

--- a/RNSecureStorage.podspec
+++ b/RNSecureStorage.podspec
@@ -11,12 +11,11 @@ Pod::Spec.new do |s|
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@parity.io" }
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://github.com/paritytech/RNSecureStorage.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/paritytech/react-native-secure-storage.git", :tag => "master" }
   s.source_files  = "RNSecureStorage/**/*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"
 
 end
-
 

--- a/RNSecureStorage.podspec
+++ b/RNSecureStorage.podspec
@@ -1,24 +1,22 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNSecureStorage"
-  s.version      = "1.0.0"
-  s.summary      = "RNSecureStorage"
+  s.version      = "1.0.1"
+  s.summary      = "React Native Secure Storage Module"
   s.description  = <<-DESC
                   RNSecureStorage
                    DESC
   s.homepage     = "https://github.com/paritytech/react-native-secure-storage/"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNSecureStorage.git", :tag => "master" }
+  s.author             = { "author" => "author@parity.io" }
+  s.platform     = :ios, "9.0"
+  s.source       = { :git => "https://github.com/paritytech/RNSecureStorage.git", :tag => "master" }
   s.source_files  = "RNSecureStorage/**/*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
 
 end
 
-  
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'react-native-secure-storage' {
+	export interface SecureStoreParams {
+		keychainService: string;
+		sharedPreferencesName: string;
+	}
+
+	export function getAllItems(store: SecureStoreParams): Promise<{ [key: string]: string }>;
+
+	export function getItem(itemLabel: string, store: SecureStoreParams): Promise<string>;
+
+	export function setItem(
+		itemLabel: string,
+		item: any,
+		store: SecureStoreParams
+	): Promise<void>;
+
+	export function deleteItem(itemLabel: string, store: SecureStoreParams): Promise<void>;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-secure-storage",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR closes #5 ,  includes 3 parts:

### 1. Fix the CocoaPods Specs.

React Native > 0.60 use `pod` to link libraries, the `.podspecs` is under wrong position with incomplete settings. Now it can be automatically detected with `pod install`.

### 2. Update ReadMe with Usages.

### 3. Add types declaration for typescript.