### PR TITLE
fix: podspec paths and remove peerDependencies

### DIFF
--- a/RNSecureStorage.podspec
+++ b/RNSecureStorage.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author             = { "author" => "author@parity.io" }
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/paritytech/react-native-secure-storage.git", :tag => "master" }
-  s.source_files  = "RNSecureStorage/**/*.{h,m}"
+  s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
 {
   "name": "react-native-secure-storage",
   "version": "1.0.1",
-  "description": "",
+  "description": "React Native Secure Storage Module",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "react-native"
+    "react-native, secure-storage"
   ],
   "author": "",
   "license": "",
-  "peerDependencies": {
+  "devDependencies": {
     "react-native": "^0.40.0"
   }
 }


### PR DESCRIPTION
path setting in podspec file is not correct.

Change `peerDependencies` to `devDependencies` to eliminate warning when starting react native server.